### PR TITLE
CIWEMB-149: Add contribution tab configuration warning

### DIFF
--- a/js/webform_multicompanyaccounting.js
+++ b/js/webform_multicompanyaccounting.js
@@ -1,0 +1,24 @@
+CRM.$(document).ready(function ($) {
+  Drupal.behaviors.webformMulticompanyaccounting = {
+    attach: function (context) {
+      $('#edit-civicrm-1-contribution-1-contribution-contribution-page-id').change(function () {
+        $('#webformMulticompanyaccounting-configure-ft').remove();
+
+        var contributionPageId = $('#edit-civicrm-1-contribution-1-contribution-contribution-page-id').val();
+        if (contributionPageId == 0) {
+          return;
+        }
+
+        var message = Drupal.t('For multicompany accounting to work correctly it is important to make sure that the owner organisation of the financial type of the contribution page matches the owner organisation of the financial type of any memberships added to the form. Failing to do so will lead to errors when generating invoices.');
+        $('#civicrm-ajax-contribution-sets').before(
+          '<div id="webformMulticompanyaccounting-configure-ft" class="messages warning">' +
+          message +
+          ' ' +
+          '<a href="/civicrm/admin/contribute/settings?reset=1&action=update&id=' + contributionPageId + '">' +
+          Drupal.t('Configure') +
+          '</a></div>'
+        );
+      });
+    }
+  }
+}(jQuery));

--- a/webform_multicompanyaccounting.module
+++ b/webform_multicompanyaccounting.module
@@ -1,1 +1,10 @@
 <?php
+
+/**
+ * Implements of hook form_alter()
+ */
+function webform_multicompanyaccounting_form_alter(&$form, &$form_state, $form_id) {
+  if ($form_id == 'wf_crm_configure_form') {
+    drupal_add_js(drupal_get_path('module', 'webform_multicompanyaccounting') . '/js/webform_multicompanyaccounting.js');
+  }
+}


### PR DESCRIPTION
## Overview

As part of the work I did here: https://github.com/compucorp/io.compuco.multicompanyaccounting/pull/9
I talked about the need for validation/warning on the Price Sets and Webforms to make sure the admins do not miss configure the sites that uses multi company accounting.

The Price Sets work validation is done here: https://github.com/compucorp/io.compuco.multicompanyaccounting/pull/10


For Webforms, there are two ways in which the admin can configure a webform with contribution(s):

1- Contribution(s) without membership(s), in this case the admin cannot select the financial type and it will be selected automatically based on the "Financial Type" that is configured on the Webform contribution page.

2- Contribution with Memberships,  the admin can either select the financial type or set it to Automatic, You can also configure the webform so the list of Memberships are manually selected by the user, because of that it really hard to know which Financial Types will be used on that webform, so we are leaving it to the Admin to make sure whatever Memberships are allowed on that Webform, should have financial types that have an owner account on the income account, that matches the owner of the income account on the financial type configured on the contribution page.  In this module we are adding a warning message to help the admins to keep that in mind.

![2023-02-13 20_24_54-test _ compuclient142sspv1](https://user-images.githubusercontent.com/6275540/218528478-444cc480-b31b-469a-8044-f6e392fcf8b3.png)
